### PR TITLE
Allow subnet selection for VPC Endpoints

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -46,7 +46,10 @@ locals {
   gateway_endpoint_map = { for v in var.gateway_vpc_endpoints : v => {
     name            = v
     policy          = null
-    route_table_ids = module.subnets.private_route_table_ids
+    
+    # If var.vpc_endpoints_subnet_name is empty, fallback to the previous behaviour of provisioning the 
+    # endpoints on all private subnets. If a subnet name is provided, use it as index into the named private subnets map
+    route_table_ids = var.vpc_endpoints_subnet_name == "" ? module.subnets.private_route_table_ids : module.subnets.named_private_route_table_ids_map[var.vpc_endpoints_subnet_name]
   } }
 
   # If we use a separate security group for each endpoint interface,
@@ -61,7 +64,10 @@ locals {
     policy              = null
     private_dns_enabled = true # Allow applications to use normal service DNS names to access the service
     security_group_ids  = [module.endpoint_security_groups[local.interface_endpoint_security_group_key].id]
-    subnet_ids          = module.subnets.private_subnet_ids
+    
+    # If var.vpc_endpoints_subnet_name is empty, fallback to the previous behaviour of provisioning the 
+    # endpoints on all private subnets. If a subnet name is provided, use it as index into the named private subnets map
+    subnet_ids          = var.vpc_endpoints_subnet_name == "" ? module.subnets.private_subnet_ids : module.subnets.named_private_subnets_map[var.vpc_endpoints_subnet_name]
   } }
 }
 

--- a/src/main.tf
+++ b/src/main.tf
@@ -48,7 +48,7 @@ locals {
     policy          = null
     
     # If var.vpc_endpoints_subnet_name is empty, fallback to the previous behaviour of provisioning the 
-    # endpoints on all private subnets. If a subnet name is provided, use it as index into the named private subnets map
+    # endpoints on all private subnets. If a subnet name is provided, use it as index into the named private subnets route table map
     route_table_ids = var.vpc_endpoints_subnet_name == "" ? module.subnets.private_route_table_ids : module.subnets.named_private_route_table_ids_map[var.vpc_endpoints_subnet_name]
   } }
 

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -218,6 +218,16 @@ variable "interface_vpc_endpoints" {
   default     = []
 }
 
+variable "vpc_endpoints_subnet_name" {
+  type        = string
+  description = <<-EOT
+    The name of the subnet from the `subnets_per_az_names` in which to create Interface and Gateway VPC endpoints.
+    If `vpc_endpoints_subnet_name` is not provided, Interface and Gateway VPC endpoints will be created in all private route tables.
+  EOT
+  default     = ""
+  nullable    = false
+}
+
 variable "subnets_per_az_count" {
   type        = number
   description = <<-EOT


### PR DESCRIPTION
VPC Endpoints subnet selection.

* Added a new variable `vpc_endpoints_subnet_name`
  Specifies the name of a subnet from `subnets_per_az_names` in which to create Interface and Gateway VPC endpoints.

* By default, `vpc_endpoints_subnet_name` is empty, and so Interface and Gateway VPC endpoints will be created in all private route tables, which maintains the previous behavior. 

Note: based on @aknysh code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to target a specific subnet (by name) for Interface and Gateway VPC endpoints; when unset, endpoints continue to use all private subnets/route tables.
* **Bug Fixes**
  * Enforced validation to ensure the subnets-per-AZ value is greater than 0, preventing invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->