### PR TITLE
fix: VPC Endpoint Outputs

### DIFF
--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -141,32 +141,32 @@ output "nat_eip_protections" {
 
 output "interface_vpc_endpoints" {
   description = "List of Interface VPC Endpoints in this VPC."
-  value       = try(module.vpc_endpoints.interface_vpc_endpoints, [])
+  value       = try(module.vpc_endpoints.interface_vpc_endpoints_map, [])
 }
 
 output "gateway_vpc_endpoints" {
   description = "Map of Gateway VPC Endpoints in this VPC, keyed by service (e.g. \"s3\")."
-  value       = try(module.vpc_endpoints.gateway_vpc_endpoints, {})
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints_map, {})
 }
 
 output "vpc_endpoint_s3_prefix_list_id" {
   description = "Prefix list ID for S3 gateway endpoint"
-  value       = try(module.vpc_endpoints.gateway_vpc_endpoints["s3"]["prefix_list_id"], null)
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints_map["s3"]["prefix_list_id"], null)
 }
 
 output "vpc_endpoint_s3_id" {
   description = "ID of the S3 gateway endpoint"
-  value       = try(module.vpc_endpoints.gateway_vpc_endpoints["s3"]["id"], null)
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints_map["s3"]["id"], null)
 }
 
 output "vpc_endpoint_dynamodb_prefix_list_id" {
   description = "Prefix list ID for DynamoDB gateway endpoint"
-  value       = try(module.vpc_endpoints.gateway_vpc_endpoints["dynamodb"]["prefix_list_id"], null)
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints_map["dynamodb"]["prefix_list_id"], null)
 }
 
 output "vpc_endpoint_dynamodb_id" {
   description = "ID of the DynamoDB gateway endpoint"
-  value       = try(module.vpc_endpoints.gateway_vpc_endpoints["dynamodb"]["id"], null)
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints_map["dynamodb"]["id"], null)
 }
 
 output "vpc_endpoint_interface_security_group_id" {

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -140,7 +140,7 @@ output "nat_eip_protections" {
 }
 
 output "interface_vpc_endpoints" {
-  description = "List of Interface VPC Endpoints in this VPC."
+  description = "Map of Interface VPC Endpoints in this VPC."
   value       = try(module.vpc_endpoints.interface_vpc_endpoints_map, [])
 }
 

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -141,7 +141,7 @@ output "nat_eip_protections" {
 
 output "interface_vpc_endpoints" {
   description = "Map of Interface VPC Endpoints in this VPC."
-  value       = try(module.vpc_endpoints.interface_vpc_endpoints_map, [])
+  value       = try(module.vpc_endpoints.interface_vpc_endpoints_map, {})
 }
 
 output "gateway_vpc_endpoints" {

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -141,32 +141,32 @@ output "nat_eip_protections" {
 
 output "interface_vpc_endpoints" {
   description = "List of Interface VPC Endpoints in this VPC."
-  value       = try(module.vpc_endpoints[0].interface_vpc_endpoints, [])
+  value       = try(module.vpc_endpoints.interface_vpc_endpoints, [])
 }
 
 output "gateway_vpc_endpoints" {
   description = "Map of Gateway VPC Endpoints in this VPC, keyed by service (e.g. \"s3\")."
-  value       = try(module.vpc_endpoints[0].gateway_vpc_endpoints, {})
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints, {})
 }
 
 output "vpc_endpoint_s3_prefix_list_id" {
   description = "Prefix list ID for S3 gateway endpoint"
-  value       = try(module.vpc_endpoints[0].gateway_vpc_endpoints["s3"]["prefix_list_id"], null)
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints["s3"]["prefix_list_id"], null)
 }
 
 output "vpc_endpoint_s3_id" {
   description = "ID of the S3 gateway endpoint"
-  value       = try(module.vpc_endpoints[0].gateway_vpc_endpoints["s3"]["id"], null)
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints["s3"]["id"], null)
 }
 
 output "vpc_endpoint_dynamodb_prefix_list_id" {
   description = "Prefix list ID for DynamoDB gateway endpoint"
-  value       = try(module.vpc_endpoints[0].gateway_vpc_endpoints["dynamodb"]["prefix_list_id"], null)
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints["dynamodb"]["prefix_list_id"], null)
 }
 
 output "vpc_endpoint_dynamodb_id" {
   description = "ID of the DynamoDB gateway endpoint"
-  value       = try(module.vpc_endpoints[0].gateway_vpc_endpoints["dynamodb"]["id"], null)
+  value       = try(module.vpc_endpoints.gateway_vpc_endpoints["dynamodb"]["id"], null)
 }
 
 output "vpc_endpoint_interface_security_group_id" {

--- a/test/component_test.go
+++ b/test/component_test.go
@@ -219,7 +219,7 @@ func (s *ComponentSuite) TestVPCWithEndpoints() {
 	assert.True(s.T(), strings.HasPrefix(dynamodbPrefixListId, "pl-"), "DynamoDB prefix list ID should have correct format")
 
 	// Test Interface VPC Endpoints outputs
-	interfaceEndpoints := atmos.OutputList(s.T(), options, "interface_vpc_endpoints")
+	interfaceEndpoints := atmos.OutputMap(s.T(), options, "interface_vpc_endpoints")
 	assert.NotEmpty(s.T(), interfaceEndpoints, "Interface VPC endpoints should not be empty")
 	assert.Equal(s.T(), 2, len(interfaceEndpoints), "Should have 2 interface endpoints (ec2 and ssm)")
 

--- a/test/fixtures/stacks/catalog/usecase/with_endpoints.yaml
+++ b/test/fixtures/stacks/catalog/usecase/with_endpoints.yaml
@@ -1,0 +1,24 @@
+components:
+  terraform:
+    vpc/with_endpoints:
+      metadata:
+        component: target
+      vars:
+        name: "vpc-terraform"
+        availability_zones:
+          - "a"
+          - "b"
+        public_subnets_enabled: false
+        nat_gateway_enabled: false
+        nat_instance_enabled: false
+        subnet_type_tag_key: "eg.cptest.co/subnet/type"
+        max_subnet_count: 3
+        vpc_flow_logs_enabled: false
+        ipv4_primary_cidr_block: "172.16.0.0/16"
+        # Configure VPC endpoints for testing
+        gateway_vpc_endpoints:
+          - "s3"
+          - "dynamodb"
+        interface_vpc_endpoints:
+          - "ec2"
+          - "ssm"

--- a/test/fixtures/stacks/orgs/default/test/tests.yaml
+++ b/test/fixtures/stacks/orgs/default/test/tests.yaml
@@ -5,4 +5,5 @@ import:
   - catalog/usecase/private
   - catalog/usecase/public
   - catalog/usecase/with_flowlogs
+  - catalog/usecase/with_endpoints
 #  - catalog/usecase/with_ipam


### PR DESCRIPTION
## what
- Fixed outputs for VPC Endpoints
- Added tests

## why
- #62 used an index incorrectly. Added a test to catch this next time

## references
- .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - VPC endpoint outputs now use service-keyed maps for both interface and gateway endpoints, improving clarity and direct access.
  - Outputs include S3 and DynamoDB endpoint IDs and prefix list IDs.
  - Interface endpoint security group ID is exposed via outputs.

- Tests
  - Added end-to-end test for a VPC with endpoints, validating gateway/interface endpoint outputs and formats.
  - Introduced test fixtures and stack import for the VPC-with-endpoints use case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->