### PR TITLE
chore: update terraform-aws-dynamic-subnets to v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,12 @@ This component is responsible for provisioning a VPC and corresponding Subnets w
 - VPC Endpoints for AWS services (S3, DynamoDB, and interface endpoints)
 - AWS Shield Advanced protection for NAT Gateway EIPs (optional)
 
-**What's New in v3.0.1:**
-- Uses `terraform-aws-dynamic-subnets` v3.0.1 with enhanced subnet configuration
+**What's New in v3.1.0:**
+- Uses `terraform-aws-dynamic-subnets` v3.1.0 with enhanced subnet configuration
 - Separate public/private subnet counts and names per AZ
 - Precise NAT Gateway placement control for cost optimization
-- NAT Gateway IDs exposed in subnet stats outputs
+- NAT Gateway IDs and private IPs exposed in subnet stats outputs
 - Requires AWS Provider v5.0+
-- Fixes critical bug in NAT routing when `max_nats < num_azs`
 
 
 > [!TIP]
@@ -308,7 +307,7 @@ components:
 |------|--------|---------|
 | <a name="module_endpoint_security_groups"></a> [endpoint\_security\_groups](#module\_endpoint\_security\_groups) | cloudposse/security-group/aws | 2.2.0 |
 | <a name="module_iam_roles"></a> [iam\_roles](#module\_iam\_roles) | ../account-map/modules/iam-roles | n/a |
-| <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 3.0.1 |
+| <a name="module_subnets"></a> [subnets](#module\_subnets) | cloudposse/dynamic-subnets/aws | 3.1.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 | <a name="module_utils"></a> [utils](#module\_utils) | cloudposse/utils/aws | 1.4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | cloudposse/vpc/aws | 3.0.0 |
@@ -461,8 +460,8 @@ For additional context, refer to some of these links.
 
 - [cloudposse-terraform-components](https://github.com/orgs/cloudposse-terraform-components/repositories) - Cloud Posse's upstream component
 - [terraform-aws-vpc](https://github.com/cloudposse/terraform-aws-vpc) - CloudPosse VPC Module v3.0.0
-- [terraform-aws-dynamic-subnets](https://github.com/cloudposse/terraform-aws-dynamic-subnets) - CloudPosse Dynamic Subnets Module v3.0.1 - Enhanced subnet configuration with separate public/private control
-- [terraform-aws-dynamic-subnets v3.0.1 Release](https://github.com/cloudposse/terraform-aws-dynamic-subnets/releases/tag/v3.0.1) - Patch release fixing NAT routing bug when max_nats < num_azs
+- [terraform-aws-dynamic-subnets](https://github.com/cloudposse/terraform-aws-dynamic-subnets) - CloudPosse Dynamic Subnets Module v3.1.0 - Enhanced subnet configuration with separate public/private control
+- [terraform-aws-dynamic-subnets v3.1.0 Release](https://github.com/cloudposse/terraform-aws-dynamic-subnets/releases/tag/v3.1.0) - Adds nat_gateway_private_ips output for NAT Gateway private IP addresses
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -14,13 +14,12 @@ description: |-
   - VPC Endpoints for AWS services (S3, DynamoDB, and interface endpoints)
   - AWS Shield Advanced protection for NAT Gateway EIPs (optional)
 
-  **What's New in v3.0.1:**
-  - Uses `terraform-aws-dynamic-subnets` v3.0.1 with enhanced subnet configuration
+  **What's New in v3.1.0:**
+  - Uses `terraform-aws-dynamic-subnets` v3.1.0 with enhanced subnet configuration
   - Separate public/private subnet counts and names per AZ
   - Precise NAT Gateway placement control for cost optimization
-  - NAT Gateway IDs exposed in subnet stats outputs
+  - NAT Gateway IDs and private IPs exposed in subnet stats outputs
   - Requires AWS Provider v5.0+
-  - Fixes critical bug in NAT routing when `max_nats < num_azs`
 
 usage: |-
   **Stack Level**: Regional
@@ -237,11 +236,11 @@ references:
     description: CloudPosse VPC Module v3.0.0
     url: https://github.com/cloudposse/terraform-aws-vpc
   - name: terraform-aws-dynamic-subnets
-    description: CloudPosse Dynamic Subnets Module v3.0.1 - Enhanced subnet configuration with separate public/private control
+    description: CloudPosse Dynamic Subnets Module v3.1.0 - Enhanced subnet configuration with separate public/private control
     url: https://github.com/cloudposse/terraform-aws-dynamic-subnets
-  - name: terraform-aws-dynamic-subnets v3.0.1 Release
-    description: Patch release fixing NAT routing bug when max_nats < num_azs
-    url: https://github.com/cloudposse/terraform-aws-dynamic-subnets/releases/tag/v3.0.1
+  - name: terraform-aws-dynamic-subnets v3.1.0 Release
+    description: Adds nat_gateway_private_ips output for NAT Gateway private IP addresses
+    url: https://github.com/cloudposse/terraform-aws-dynamic-subnets/releases/tag/v3.1.0
 tags:
   - component/vpc
   - layer/network

--- a/src/main.tf
+++ b/src/main.tf
@@ -158,7 +158,7 @@ resource "null_resource" "nat_placement_validation" {
 
 module "subnets" {
   source  = "cloudposse/dynamic-subnets/aws"
-  version = "3.0.1"
+  version = "3.1.0"
 
   # Ensure validation runs before subnets module
   depends_on = [null_resource.nat_placement_validation]


### PR DESCRIPTION
## Summary
Updates the CloudPosse dynamic subnets module from v3.0.1 to v3.1.0, which adds a new `nat_gateway_private_ips` output for accessing NAT Gateway private IP addresses. This is a non-breaking update that enables users to configure internal networking like security group rules and route debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NAT Gateway outputs now include private IP addresses in addition to gateway IDs, providing enhanced subnet configuration visibility.

* **Documentation**
  * Module version updated to v3.1.0 across configuration and documentation.
  * Added documentation for NAT Gateway private IP address outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->