### PR TITLE
chore: migrate Renovate config preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "prConcurrentLimit": 5,
   "extends": [
-    "config:base"
+    "config:recommended"
   ]
 }


### PR DESCRIPTION
## Summary
- migrate Renovate from deprecated `config:base` to `config:recommended`
- preserve the existing `prConcurrentLimit`

## Verification
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`

Note: I did not run `atmos test run` because this repository's AGENTS.md says the Terratest suite deploys/destroys real AWS resources and may incur AWS costs; this PR only changes Renovate configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use an enhanced preset ruleset, improving the consistency and quality of automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->